### PR TITLE
Platform compatibility fixes

### DIFF
--- a/src/crypto_impl.c
+++ b/src/crypto_impl.c
@@ -1804,7 +1804,10 @@ int sqlcipher_set_log(const char *destination){
     sqlcipher_log_file = stderr;
   }else if(sqlite3_stricmp(destination, "off") != 0){
 #if !defined(SQLCIPHER_PROFILE_USE_FOPEN) && (defined(_WIN32) && (__STDC_VERSION__ > 199901L) || defined(SQLITE_OS_WINRT))
-    if(fopen_s(&((FILE*)sqlcipher_log_file), destination, "a") != 0) return SQLITE_ERROR;
+    // create a non-volatile FILE* for use with fopen_s
+    // we need to do this because we use more strict compile flags
+    FILE* nv_sqlcipher_log_file = (FILE*)sqlcipher_log_file;
+    if(fopen_s(&nv_sqlcipher_log_file, destination, "a") != 0) return SQLITE_ERROR;
 #else
     if((sqlcipher_log_file = fopen(destination, "a")) == 0) return SQLITE_ERROR;
 #endif

--- a/src/crypto_impl.c
+++ b/src/crypto_impl.c
@@ -1751,8 +1751,8 @@ void sqlcipher_log(unsigned int level, const char *message, ...) {
     ULARGE_INTEGER ull;
     GetSystemTime(&st);
     SystemTimeToFileTime(&st, &ft);
-    ull.LowPart = ft.dwLowDateTime
-    ull.HighPart = ft.dwHighDateTime
+    ull.LowPart = ft.dwLowDateTime;
+    ull.HighPart = ft.dwHighDateTime;
     sec = (time_t) ((ull.QuadPart - FILETIME_1970) / HECTONANOSEC_PER_SEC);
     /*sec = (time_t) ((*((sqlite_int64*)&ft) - FILETIME_1970) / HECTONANOSEC_PER_SEC);*/
     ms = st.wMilliseconds;


### PR DESCRIPTION
<!--
Make sure that your pull request is based on the `prerelease` branch.
-->

Changes proposed in this pull request:
- Fix strict pointer aliasing error in WIN32 timestamp calculation
- Fix volatile FILE* used as non-volatile FILE* with temp variable cast for WIN32 builds
